### PR TITLE
Changes to the command line (--append, --no-output) and CSV File (Region, Timestamp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,15 @@ The following command line arguments are supported:
 
 Argument         | Meaning
 -----------------|----------------------------------
---append         | Append (rather than overwrite) the output file.
 --help           | Information on the command line options
---output-file OF | Write the results in Comma Separated Values format to file OF.
+--output-file OF | Write the results in Comma Separated Values format to file OF. Defaults to 'resources.csv'.
+--no-output      | Do not save the results to any file.
 --profile PN     | Use the credentials associated with shared profile named PN.
 --region RN      | Collect resource counts for a single AWS region RN. If omitted, all regions are examined.
 --trace-file TF  | Write a trace of all AWS calls to file TF.
 --version        | Display version information and then exit.
+
+When run repeatedly, results are automatically **appended** to the existing file. If you wish to not save the results of a run to _any_ file, use `--no-output`.
 
 ## Installing
 
@@ -80,7 +82,7 @@ To use this utility, this minimal IAM Profile can be associated with a bare user
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "VisualEditor0",
+            "Sid": "Cloud Resource Counter Permissions",
             "Effect": "Allow",
             "Action": [
                 "ec2:DescribeInstances",

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"os"
+	"time"
 )
 
 // The version of this tool. This is supplied by the build process.
@@ -76,16 +77,26 @@ func main() {
 	}
 	results.Init()
 
+	// Get the display name of the selected region
+	var displayRegion string
+	if settings.allRegions {
+		displayRegion = "ALL_REGIONS"
+	} else {
+		displayRegion = settings.regionName
+	}
+
 	// Create a new row of data
 	results.NewRow()
 	results.Append("Account ID", GetAccountID(serviceFactory.GetAccountIDService(), monitor))
-	results.Append("# of EC2 Instances", EC2Counts(serviceFactory, monitor, settings.regionName == ""))
-	results.Append("# of Spot Instances", SpotInstances(serviceFactory, monitor, settings.regionName == ""))
-	results.Append("# of EBS Volumes", EBSVolumes(serviceFactory, monitor, settings.regionName == ""))
-	results.Append("# of Unique Containers", UniqueContainerImages(serviceFactory, monitor, settings.regionName == ""))
-	results.Append("# of Lambda Functions", LambdaFunctions(serviceFactory, monitor, settings.regionName == ""))
-	results.Append("# of RDS Instances", RDSInstances(serviceFactory, monitor, settings.regionName == ""))
-	results.Append("# of Lightsail Instances", LightsailInstances(serviceFactory, monitor, settings.regionName == ""))
+	results.Append("Timestamp", time.Now().Format(time.RFC3339))
+	results.Append("Region", displayRegion)
+	results.Append("# of EC2 Instances", EC2Counts(serviceFactory, monitor, settings.allRegions))
+	results.Append("# of Spot Instances", SpotInstances(serviceFactory, monitor, settings.allRegions))
+	results.Append("# of EBS Volumes", EBSVolumes(serviceFactory, monitor, settings.allRegions))
+	results.Append("# of Unique Containers", UniqueContainerImages(serviceFactory, monitor, settings.allRegions))
+	results.Append("# of Lambda Functions", LambdaFunctions(serviceFactory, monitor, settings.allRegions))
+	results.Append("# of RDS Instances", RDSInstances(serviceFactory, monitor, settings.allRegions))
+	results.Append("# of Lightsail Instances", LightsailInstances(serviceFactory, monitor, settings.allRegions))
 	results.Append("# of S3 Buckets", S3Buckets(serviceFactory, monitor))
 
 	/* =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/utils.go
+++ b/utils.go
@@ -97,3 +97,17 @@ func Map(vs []string, f func(string) string) []string {
 func NilInterface(intf interface{}) bool {
 	return intf == nil || reflect.ValueOf(intf).IsNil()
 }
+
+// FileExists checks if a file exists and is not a directory before we
+// try using it to prevent further errors.
+func FileExists(fileName string) bool {
+	// Stat the file
+	info, err := os.Stat(fileName)
+
+	// Check for non-existent file
+	if os.IsNotExist(err) {
+		return false
+	}
+
+	return !info.IsDir()
+}


### PR DESCRIPTION
1. Added `--no-output` flag to not save results anywhere.
1. Removed `--append` and made it default.
1. Fixed `Sid` of IAM Policy in `README.md`.
1. Updated unit tests for command line changes.
1. Added Region name and time stamp to CSV file.