### PR TITLE
Build on main instead of master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build, Lint and Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
 


### PR DESCRIPTION
This is to support our our migration from `master` to `main` as the default branch for this repo, as `main` is a more inclusive term.