### PR TITLE
MET-14 renaming from cloud-resource-counter to aws-resource-counter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 resources.csv
 coverage.out
-cloud-resource-counter
+aws-resource-counter
 .vscode/
 dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,11 +7,11 @@ before:
     # you may remove this if you don't need go generate
     # - go generate ./...
 builds:
-  - binary: cloud-resource-counter
+  - binary: aws-resource-counter
     id: crc-others
     goos:
       - linux
-  - binary: cloud-resource-counter
+  - binary: aws-resource-counter
     id: crc-macos
     goos:
       - darwin

--- a/CI_CD.md
+++ b/CI_CD.md
@@ -26,7 +26,7 @@ This page describes the Continuous Integration/Continuous Delivery configuration
 
 ## Code Signing and Notarization
 
-The MacOS operating system (starting with Catalina) is much more strict as it relates to allowing binaries from the Internet to be downloaded and run. To allow the `cloud-resource-counter` binary to be run on customer's machine, the customer must allow binaries from "identified developers" and our binary needs to be "signed and notarized".
+The MacOS operating system (starting with Catalina) is much more strict as it relates to allowing binaries from the Internet to be downloaded and run. To allow the `aws-resource-counter` binary to be run on customer's machine, the customer must allow binaries from "identified developers" and our binary needs to be "signed and notarized".
 
 The process of code signing involves Apple Services to complete (along with an Apple ID account and an Apple Developer ID Application certificate).
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# cloud-resource-counter
+# aws-resource-counter
 
-![Build, Lint and Test](https://github.com/expel-io/cloud-resource-counter/workflows/Build,%20Lint%20and%20Test/badge.svg?branch=master) ![Release with goreleaser](https://github.com/expel-io/cloud-resource-counter/workflows/Release%20with%20goreleaser/badge.svg)
+![Build, Lint and Test](https://github.com/expel-io/aws-resource-counter/workflows/Build,%20Lint%20and%20Test/badge.svg?branch=master) ![Release with goreleaser](https://github.com/expel-io/aws-resource-counter/workflows/Release%20with%20goreleaser/badge.svg)
 
-Go utility for counting the resources in use at a cloud infrastructure provider.
+Go utility for counting the resources in use in an AWS organization.
 
-The cloud resource counter utility known as "cloud-resource-counter" inspects
-a cloud deployment (for now, only Amazon Web Services) to assess the number of
+The AWS resource counter utility known as "aws-resource-counter" inspects
+a cloud deployment on Amazon Web Services to assess the number of
 distinct computing resources. The result is a CSV file that describes the counts
 of each.
 
@@ -14,7 +14,7 @@ of each.
 * [Command Line](#command-line)
   * [AWS CLI Setup](#aws-cli-setup)
   * [Saving Credentials in a Profile](#saving-credentials-in-a-profile)
-  * [Using cloud-resource-counter](#using-cloud-resource-counter)
+  * [Using aws-resource-counter](#using-aws-resource-counter)
   * [Repeated Usage](#repeated-usage)
 * [Sample Run, CSV File](#sample-run-csv-file)
 * [Installing](#installing)
@@ -63,7 +63,7 @@ where `some-profile-name` is the name you would like to use to name this set of 
 
 For help on storing AWS credentials, see [Configuration Basics](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html).
 
-### Using cloud-resource-counter
+### Using aws-resource-counter
 
 The following command line arguments are supported:
 
@@ -99,7 +99,7 @@ If you wish to not save the results of a run to _any_ file, use the `--no-output
 Here is what it looks like when you run the tool:
 
 ```bash
-$ cloud-resource-counter
+$ aws-resource-counter
 Cloud Resource Counter (v0.7.0) running with:
  o AWS Profile: default
  o AWS Region:  (All regions supported by this account)
@@ -142,27 +142,27 @@ The rest of the columns refer to specific counts of a type of resource.
 
 ## Installing
 
-You can build this from source or use the precompiled binaries (see the [Releases](https://github.com/expel-io/cloud-resource-counter/releases) page for binaries). We provided binaries for Linux (x86_64 and i386) and MacOS. There is no installation process as this is simply a command line tool.
+You can build this from source or use the precompiled binaries (see the [Releases](https://github.com/expel-io/aws-resource-counter/releases) page for binaries). We provided binaries for Linux (x86_64 and i386) and MacOS. There is no installation process as this is simply a command line tool.
 
 To unzip and untar from the command line on MacOS, use this command:
 
 ```bash
-$ tar -Zxvf cloud-resource-counter_<<RELEASE_VERSION>>_<<PLATFORM>>_<<ARCH>>.tar.gz
+$ tar -Zxvf aws-resource-counter_<<RELEASE_VERSION>>_<<PLATFORM>>_<<ARCH>>.tar.gz
 x LICENSE
 x README.md
-x cloud-resource-counter
+x aws-resource-counter
 ```
 
 The command on Linux is similar:
 
 ```bash
-$ tar -zxvf cloud-resource-counter_<<RELEASE_VERSION>>_<<PLATFORM>>_<<ARCH>>.tar.gz
+$ tar -zxvf aws-resource-counter_<<RELEASE_VERSION>>_<<PLATFORM>>_<<ARCH>>.tar.gz
 x LICENSE
 x README.md
-x cloud-resource-counter
+x aws-resource-counter
 ```
 
-The result is a binary called `cloud-resource-counter` in the current directory.
+The result is a binary called `aws-resource-counter` in the current directory.
 
 These binaries can run on Linux OSes (32- and 64-bit versions) and MacOS (10.12 Sierra or later).
 
@@ -188,14 +188,14 @@ You can also build this utility directly from source. We have built and tested t
 To run from source, use the following command line:
 
 ```bash
-// Assumes that you are inside the cloud-resource-counter folder
+// Assumes that you are inside the aws-resource-counter folder
 $ go run . --help
 ```
 
 To run the unit tests, use the following command line:
 
 ```bash
-// Assumes that you are inside the cloud-resource-counter folder
+// Assumes that you are inside the aws-resource-counter folder
 $ go test
 ```
 
@@ -230,7 +230,7 @@ To use this utility, this minimal IAM Profile can be associated with a bare user
 
 ## Resources Counted
 
-The `cloud-resource-counter` examines the following resources:
+The `aws-resource-counter` examines the following resources:
 
 1. **Account ID.** We use the Security Token Service to collect the account ID associated with the caller.
 
@@ -279,7 +279,7 @@ The `cloud-resource-counter` examines the following resources:
 
 ## Alternative Means of Resource Counting
 
-If you do not wish to use the `cloud-resource-counter` utility, you can use the AWS CLI to collect these same counts. For some of these counts, it will be easy to do. For others, the command line is a bit more complex.
+If you do not wish to use the `aws-resource-counter` utility, you can use the AWS CLI to collect these same counts. For some of these counts, it will be easy to do. For others, the command line is a bit more complex.
 
 If you do not have the AWS CLI (version 2) installed, see [Installing the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) on the AWS website.
 

--- a/accountId_test.go
+++ b/accountId_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 
-	"github.com/expel-io/cloud-resource-counter/mock"
+	"github.com/expel-io/aws-resource-counter/mock"
 )
 
 // This type "stands in" for the real SecurityTokenService. It implements

--- a/commandLine.go
+++ b/commandLine.go
@@ -41,7 +41,7 @@ type CommandLineSettings struct {
 
 // Process inspects the command line for valid arguments.
 //
-// Usage of cloud-resource-counter
+// Usage of aws-resource-counter
 //   --sso:            Use SSO for authentication
 //   --output-file OF: Write the results to file OF. Defaults to 'resources.csv'
 //   --no-output:      If set, then the results are not saved to any file.

--- a/commandLine_test.go
+++ b/commandLine_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/expel-io/cloud-resource-counter/mock"
+	"github.com/expel-io/aws-resource-counter/mock"
 )
 
 func TestCommandLineProcess(t *testing.T) {

--- a/containers_test.go
+++ b/containers_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ecs"
 	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
-	"github.com/expel-io/cloud-resource-counter/mock"
+	"github.com/expel-io/aws-resource-counter/mock"
 )
 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/ebs_test.go
+++ b/ebs_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
-	"github.com/expel-io/cloud-resource-counter/mock"
+	"github.com/expel-io/aws-resource-counter/mock"
 )
 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/ec2_test.go
+++ b/ec2_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 
-	"github.com/expel-io/cloud-resource-counter/mock"
+	"github.com/expel-io/aws-resource-counter/mock"
 )
 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/expel-io/cloud-resource-counter
+module github.com/expel-io/aws-resource-counter
 
 go 1.15
 

--- a/gon.hcl
+++ b/gon.hcl
@@ -1,5 +1,5 @@
-source = ["./dist/crc-macos_darwin_amd64/cloud-resource-counter"]
-bundle_id = "com.expel.cloud-resource-counter"
+source = ["./dist/crc-macos_darwin_amd64/aws-resource-counter"]
+bundle_id = "com.expel.aws-resource-counter"
 
 apple_id { }
 
@@ -8,5 +8,5 @@ sign {
 }
 
 zip {
-	output_path = "cloud-resource-counter.zip"
+	output_path = "aws-resource-counter.zip"
 }

--- a/lambda_test.go
+++ b/lambda_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lambda/lambdaiface"
-	"github.com/expel-io/cloud-resource-counter/mock"
+	"github.com/expel-io/aws-resource-counter/mock"
 )
 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/lightsail_test.go
+++ b/lightsail_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/lightsail"
 	"github.com/aws/aws-sdk-go/service/lightsail/lightsailiface"
-	"github.com/expel-io/cloud-resource-counter/mock"
+	"github.com/expel-io/aws-resource-counter/mock"
 )
 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ var version string = "?.?.?"
 // default variable specified by Goreleaser's ldflags settings.
 var date string = "<<never built>>"
 
-// The cloud resource counter utility known as "cloud-resource-counter" inspects
+// The cloud resource counter utility known as "aws-resource-counter" inspects
 // a cloud deployment (for now, only Amazon Web Services) to assess the number of
 // distinct computing resources. The result is a CSV file that describes the counts
 // of each.

--- a/rds_test.go
+++ b/rds_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
-	"github.com/expel-io/cloud-resource-counter/mock"
+	"github.com/expel-io/aws-resource-counter/mock"
 )
 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/results_test.go
+++ b/results_test.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/expel-io/cloud-resource-counter/mock"
+	"github.com/expel-io/aws-resource-counter/mock"
 )
 
 // Test the initialization of Results struct and invocation of NewRow

--- a/s3_test.go
+++ b/s3_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/expel-io/cloud-resource-counter/mock"
+	"github.com/expel-io/aws-resource-counter/mock"
 )
 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/spot_test.go
+++ b/spot_test.go
@@ -10,7 +10,7 @@ package main
 import (
 	"testing"
 
-	"github.com/expel-io/cloud-resource-counter/mock"
+	"github.com/expel-io/aws-resource-counter/mock"
 )
 
 // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=


### PR DESCRIPTION
per review comments in: https://docs.google.com/document/d/1kPUx2mhV1-ZnHQPGoqLiEveF-KGTQKAlGIr-mQasxcE/edit?mode=html updating name of repo/binary to `aws-resource-counter`